### PR TITLE
Critical bugfixes

### DIFF
--- a/src/components/Year/__snapshots__/year.test.js.snap
+++ b/src/components/Year/__snapshots__/year.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Year matches snapshot 1`] = `
+<div
+  className="inline field"
+  id="yearInput"
+>
+  <label
+    className="yearLabel"
+  >
+    Year: 
+  </label>
+  <div
+    className="ui input yearInput"
+  >
+    <input
+      onBlur={[Function]}
+      onChange={[Function]}
+      onKeyPress={[Function]}
+      type="number"
+      value={1900}
+    />
+  </div>
+  <div
+    className="yearSlider"
+  >
+    <div
+      className="slider"
+    />
+  </div>
+</div>
+`;

--- a/src/components/Year/index.jsx
+++ b/src/components/Year/index.jsx
@@ -34,7 +34,7 @@ const Year = ({ slide }) => {
   const [onUpdateYear] = useMutation(UPDATE_SLIDE_YEAR);
   const yearTimer = useRef();
 
-  const [tempYear, setTempYear] = useState(null);
+  const [tempYear, setTempYear] = useState('');
   const [inputYear, setInputYear] = useState(1900);
   const [open, setOpen] = useState(false);
   const [rangeError, setRangeError] = useState(false);

--- a/src/components/Year/index.jsx
+++ b/src/components/Year/index.jsx
@@ -2,14 +2,14 @@
 import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery, useMutation, gql } from '@apollo/client';
-import { Form, Input, Modal, Header, Icon, Button } from 'semantic-ui-react';
+import { Form, Input } from 'semantic-ui-react';
 import { Slider } from 'react-semantic-ui-range';
 
 import debouncedMutation from '../../lib/debouncedMutation';
 
 import styles from './Year.module.css';
 
-const GET_SLIDE_YEAR = gql`
+export const GET_SLIDE_YEAR = gql`
   query GetSlideYear($slide: ID!) {
     Slide(where: { id: $slide }) {
       id
@@ -36,7 +36,6 @@ const Year = ({ slide }) => {
 
   const [tempYear, setTempYear] = useState('');
   const [inputYear, setInputYear] = useState(1900);
-  const [open, setOpen] = useState(false);
   const [rangeError, setRangeError] = useState(false);
 
   useEffect(() => {
@@ -98,37 +97,6 @@ const Year = ({ slide }) => {
           />
         </div>
       </Form.Field>
-      <Modal
-        basic
-        onClose={() => setOpen(false)}
-        onOpen={() => setOpen(true)}
-        open={open}
-        size="small"
-      >
-        <Header icon>
-          <Icon name="calendar times outline" />
-          Are you sure you want to change the year?
-        </Header>
-        <Modal.Content>
-          <p>{`You have a selected feature or basemap selected that is tied to ${tempYear}. Changing the year will remove these selections.`}</p>
-        </Modal.Content>
-        <Modal.Actions>
-          <Button basic color="red" inverted onClick={() => setOpen(false)}>
-            <Icon name="remove" />
-            <span>{`Keep ${tempYear}`}</span>
-          </Button>
-          <Button
-            negative
-            inverted
-            onClick={() => {
-              setOpen(false);
-            }}
-          >
-            <Icon name="trash" />
-            <span>Clear selection and change year</span>
-          </Button>
-        </Modal.Actions>
-      </Modal>
     </>
   );
 };

--- a/src/components/Year/year.test.js
+++ b/src/components/Year/year.test.js
@@ -1,22 +1,15 @@
 import React from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { MockedProvider } from '@apollo/client/testing';
-import { GET_BASEMAPS, GET_SLIDE } from './graphql';
 
-import Basemaps from './index';
+import Year, { GET_SLIDE_YEAR } from './index';
 
-const basemap = {
-  id: '2',
-  ssid: '3',
-  title: 'Test',
-  thumbnail: 'http://images.imaginerio.org/test.jpg',
-};
 const mocks = [
   {
     request: {
-      query: GET_SLIDE,
+      query: GET_SLIDE_YEAR,
       variables: {
-        slide: '2',
+        slide: '1',
       },
     },
     result: {
@@ -24,25 +17,7 @@ const mocks = [
         Slide: {
           id: '1',
           year: 1900,
-          opacity: 1,
-          basemap,
         },
-      },
-    },
-  },
-  {
-    request: {
-      query: GET_BASEMAPS,
-    },
-    result: {
-      data: {
-        basemaps: [
-          {
-            ...basemap,
-            firstYear: 1800,
-            lastYear: 2000,
-          },
-        ],
       },
     },
   },
@@ -53,19 +28,13 @@ jest.mock('react-semantic-ui-range', () => {
   return { Slider };
 });
 
-jest.mock('semantic-ui-react', () => {
-  const Button = props => <div {...props} className="button" />;
-  const Segment = props => <div {...props} className="segment" />;
-  return { Button, Segment };
-});
-
 jest.mock('semantic-ui-react/dist/commonjs/addons/Portal/Portal', () => ({ children }) => children);
 
-describe('Basemaps', () => {
+describe('Year', () => {
   it('matches snapshot', async () => {
     const component = renderer.create(
       <MockedProvider mocks={mocks} addTypename={false}>
-        <Basemaps slide="2" />
+        <Year slide="1" />
       </MockedProvider>
     );
 

--- a/src/pages/edit/[project].js
+++ b/src/pages/edit/[project].js
@@ -72,7 +72,12 @@ const EditPage = () => {
   });
 
   const newSlide = () => {
-    const { order } = data.Project.slides.find(s => s.id === activeSlide);
+    let order;
+    try {
+      ({ order } = data.Project.slides.find(s => s.id === activeSlide));
+    } catch {
+      order = 1;
+    }
     return addSlide({
       variables: {
         project: {


### PR DESCRIPTION
Two critical bug fixes around the creation of new projects. New projects were failing because the `createSlide` command would throw and error and not execute leaving projects without slides.

—

Created via [Raycast](https://www.raycast.com?ref=signatureGithub)